### PR TITLE
ValueError should use original city passed in

### DIFF
--- a/uszipcode/search.py
+++ b/uszipcode/search.py
@@ -231,13 +231,13 @@ class SearchEngine(object):
         result_city_list = list()
 
         if best_match:
-            city, confidence = extractOne(city, city_pool)
+            candidte_city, confidence = extractOne(city, city_pool)
             if confidence >= min_similarity:
-                result_city_list.append(city)
+                result_city_list.append(candidate_city)
         else:
-            for city, confidence in extract(city, city_pool):
+            for candidate_city, confidence in extract(city, city_pool):
                 if confidence >= min_similarity:
-                    result_city_list.append(city)
+                    result_city_list.append(candidtate_city)
 
         if len(result_city_list) == 0:
             raise ValueError("'%s' is not a valid city name" % city)


### PR DESCRIPTION
By changing variable names in the loops for extracting cities from the city pool, the ValueError can tell the user that the city they passed in is not valid, as opposed to telling them that one of the candidate cities is not valid.