### PR TITLE
Check for dangling connections and cleanup in SearchEngine destructor

### DIFF
--- a/uszipcode/search.py
+++ b/uszipcode/search.py
@@ -94,6 +94,11 @@ class SearchEngine(object):
     def __exit__(self, *exc_info):  # pragma: no cover
         self.close()
 
+    def __del__(self):  # pragma: no cover
+        # Cleanup connection if still open
+        if self.ses:
+            self.close()
+
     def close(self):
         """
         close database connection.


### PR DESCRIPTION
This adds a simple check to cleanup dangling DB connections when the `SearchEngine` is destroyed. If the user is properly using context management using the `with` statement, this is not needed, but it prevents a class of errors where a new SearchEngine is created but `.close()` is not specifically called.