### PR TITLE
Update PyPI classifiers to supported Py versions

### DIFF
--- a/release-history.rst
+++ b/release-history.rst
@@ -14,6 +14,8 @@ Release and Version History
 
 **Miscellaneous**
 
+- Update PyPI classifiers to reflect supported Python versions (3.6 through 3.9)
+
 
 0.2.6 (2021-06-07)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -118,10 +118,10 @@ if __name__ == "__main__":
         "Operating System :: MacOS",
         "Operating System :: Unix",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ]
     """
     Full list can be found at: https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Adding these classifiers can help those who are inspecting the package
on PyPI and trying to figure out which versions of Python they can use.

Recent commits changed CI to only run Python 3.6 through 3.9:
- 3beb813b9b5a553b198b7b33b469b7bb7f2b231b
- 180008235aa2777e0157ea2a784c996d1e73de8d

Additionally, the 0.2.6 release states that only versions 3.6 and up are
supported.

Python 2.7 and 3.5 are both EOL (Python 3.6 will lose support in
December of this year), so it's helpful to not support them anymore.