### PR TITLE
Adding python-Levenshtein to silence warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ fuzzywuzzy
 haversine>=2.5.0
 SQLAlchemy>=1.4.0
 sqlalchemy_mate>=1.4.28.3
+python-Levenshtein


### PR DESCRIPTION
Silences a warning upon SearchEngine instantiation by having python-Levenshtein installed.