### PR TITLE
Fix ValueError not a valid city name exception

### DIFF
--- a/tests/test_search_4_by_city_and_state.py
+++ b/tests/test_search_4_by_city_and_state.py
@@ -121,6 +121,10 @@ class TestSearchEngine(SearchEngineBaseTest):
         res = self.search.by_population(upper=-1)
         assert len(res) == 0
 
+        # State below the confidence threshold should return empty list
+        res = self.search.by_city_and_state("Albany", "NJ")
+        assert len(res) == 0
+
     def test_bad_param(self):
         with pytest.raises(ValueError):
             self.search.query(zipcode="10001", prefix="10001", pattern="10001")

--- a/uszipcode/search.py
+++ b/uszipcode/search.py
@@ -532,10 +532,6 @@ class SearchEngine(object):
 
         # by city or state
         if (state is not None) and (city is not None):
-            state = self.find_state(state, best_match=True)[0]
-            city = self.find_city(city, state, best_match=True)[0]
-            filters.append(self.zip_klass.state == state)
-            filters.append(self.zip_klass.major_city == city)
             try:
                 state = self.find_state(state, best_match=True)[0]
                 city = self.find_city(city, state, best_match=True)[0]


### PR DESCRIPTION
I am trying to upgrade uszipcode from 0.2.6 to 1.0.1 in this PR https://github.com/ThePalaceProject/circulation/pull/1147 on a project I am working on and I'm running into a unexpected exception. 

```
ValueError: 'Alloway' is not a valid city name
```

This is being raised when calling `by_city_and_state`. Instead of a value error, I would expect an empty list to be returned. This was the case in 0.2.6. 

Looking at the code, in this commit https://github.com/MacHu-GWU/uszipcode-project/commit/d4ede94799adc4acc4e5586a461347dee13e0708 it appears that the lines I removed were copy and pasted outside of the try/except block. Perhaps this was for testing? 

After removing these copied lines, the function again works as I would expect. I added a new test case for this.