### PR TITLE
Update for breaking changes in sqlalchemy_mate

### DIFF
--- a/debug/s3_debug_sql_expression.py
+++ b/debug/s3_debug_sql_expression.py
@@ -3,10 +3,11 @@
 import sqlalchemy as sa
 import sqlalchemy.orm as orm
 import sqlalchemy_mate as sam
+import sqlalchemy_mate.api
 from uszipcode.model import SimpleZipcode, ComprehensiveZipcode
 
 db_file_path = "/Users/sanhehu/.crawl_uszipcode/comprehensive.sqlite"
-engine = sam.EngineCreator().create_sqlite(path=db_file_path)
+engine = sam.api.EngineCreator().create_sqlite(path=db_file_path)
 
 Zipcode = ComprehensiveZipcode
 with orm.Session(engine) as ses:

--- a/docs/source/01-Usage-Example/index.rst
+++ b/docs/source/01-Usage-Example/index.rst
@@ -193,9 +193,9 @@ I collect lots of feedback from organization user that people want to host the d
 
 .. code-block:: python
 
-    import sqlalchemy_mate as sam
+    from sqlalchemy_mate.api import EngineCreator
 
-    engine = sam.EngineCreator(username, password, host, port, database)..create_postgresql_pg8000()
+    engine = EngineCreator(username, password, host, port, database)..create_postgresql_pg8000()
     search = SearchEngine(engine=engine)
 
 **Deploy uszipcode as Web API**:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pathlib_mate
 atomicwrites
 fuzzywuzzy
 haversine>=2.5.0
-SQLAlchemy>=1.4.0
-sqlalchemy_mate>=1.4.28.3
+SQLAlchemy>=2.0.30
+sqlalchemy_mate>=2.0.0.1

--- a/tests/test_search_9_custom_engine.py
+++ b/tests/test_search_9_custom_engine.py
@@ -2,6 +2,7 @@
 
 import pytest
 import sqlalchemy_mate as sam
+import sqlalchemy_mate.api
 from uszipcode.search import SearchEngine, DEFAULT_SIMPLE_DB_FILE_PATH
 
 
@@ -10,7 +11,7 @@ def test_custom_engine():
     _ = SearchEngine()
 
     # use custom db engine
-    engine = sam.EngineCreator().create_sqlite(path=DEFAULT_SIMPLE_DB_FILE_PATH)
+    engine = sam.api.EngineCreator().create_sqlite(path=DEFAULT_SIMPLE_DB_FILE_PATH)
     sr = SearchEngine(engine=engine)
     z = sr.by_zipcode("10001")
     assert z.state == "NY"

--- a/uszipcode/model.py
+++ b/uszipcode/model.py
@@ -8,6 +8,7 @@ from pathlib_mate import Path
 import sqlalchemy as sa
 import sqlalchemy.orm as orm
 import sqlalchemy_mate as sam
+import sqlalchemy_mate.api
 from .state_abbr import (
     MAPPER_STATE_ABBR_SHORT_TO_LONG,
 )
@@ -27,7 +28,7 @@ class ZipcodeTypeEnum(enum.Enum):
 
 
 @total_ordering
-class AbstractSimpleZipcode(Base, sam.ExtendedBase):
+class AbstractSimpleZipcode(Base, sam.api.ExtendedBase):
     """
     Base class for Zipcode.
     """
@@ -37,7 +38,7 @@ class AbstractSimpleZipcode(Base, sam.ExtendedBase):
     zipcode_type = sa.Column(sa.String)
     major_city = sa.Column(sa.String)
     post_office_city = sa.Column(sa.String)
-    common_city_list = sa.Column(sam.types.CompressedJSONType)
+    common_city_list = sa.Column(sam.types.api.CompressedJSONType)
     county = sa.Column(sa.String)
     state = sa.Column(sa.String)
 
@@ -46,7 +47,7 @@ class AbstractSimpleZipcode(Base, sam.ExtendedBase):
 
     timezone = sa.Column(sa.String)
     radius_in_miles = sa.Column(sa.Float)
-    area_code_list = sa.Column(sam.types.CompressedJSONType)
+    area_code_list = sa.Column(sam.types.api.CompressedJSONType)
 
     population = sa.Column(sa.Integer)
     population_density = sa.Column(sa.Float)
@@ -149,61 +150,61 @@ class AbstractSimpleZipcode(Base, sam.ExtendedBase):
 class AbstractComprehensiveZipcode(AbstractSimpleZipcode):
     __abstract__ = True
 
-    polygon = sa.Column(sam.types.CompressedJSONType)
+    polygon = sa.Column(sam.types.api.CompressedJSONType)
 
     # Stats and Demographics
-    population_by_year = sa.Column(sam.types.CompressedJSONType)
-    population_by_age = sa.Column(sam.types.CompressedJSONType)
-    population_by_gender = sa.Column(sam.types.CompressedJSONType)
-    population_by_race = sa.Column(sam.types.CompressedJSONType)
-    head_of_household_by_age = sa.Column(sam.types.CompressedJSONType)
-    families_vs_singles = sa.Column(sam.types.CompressedJSONType)
-    households_with_kids = sa.Column(sam.types.CompressedJSONType)
-    children_by_age = sa.Column(sam.types.CompressedJSONType)
+    population_by_year = sa.Column(sam.types.api.CompressedJSONType)
+    population_by_age = sa.Column(sam.types.api.CompressedJSONType)
+    population_by_gender = sa.Column(sam.types.api.CompressedJSONType)
+    population_by_race = sa.Column(sam.types.api.CompressedJSONType)
+    head_of_household_by_age = sa.Column(sam.types.api.CompressedJSONType)
+    families_vs_singles = sa.Column(sam.types.api.CompressedJSONType)
+    households_with_kids = sa.Column(sam.types.api.CompressedJSONType)
+    children_by_age = sa.Column(sam.types.api.CompressedJSONType)
 
     # Real Estate and Housing
-    housing_type = sa.Column(sam.types.CompressedJSONType)
-    year_housing_was_built = sa.Column(sam.types.CompressedJSONType)
-    housing_occupancy = sa.Column(sam.types.CompressedJSONType)
-    vacancy_reason = sa.Column(sam.types.CompressedJSONType)
-    owner_occupied_home_values = sa.Column(sam.types.CompressedJSONType)
-    rental_properties_by_number_of_rooms = sa.Column(sam.types.CompressedJSONType)
+    housing_type = sa.Column(sam.types.api.CompressedJSONType)
+    year_housing_was_built = sa.Column(sam.types.api.CompressedJSONType)
+    housing_occupancy = sa.Column(sam.types.api.CompressedJSONType)
+    vacancy_reason = sa.Column(sam.types.api.CompressedJSONType)
+    owner_occupied_home_values = sa.Column(sam.types.api.CompressedJSONType)
+    rental_properties_by_number_of_rooms = sa.Column(sam.types.api.CompressedJSONType)
 
-    monthly_rent_including_utilities_studio_apt = sa.Column(sam.types.CompressedJSONType)
-    monthly_rent_including_utilities_1_b = sa.Column(sam.types.CompressedJSONType)
-    monthly_rent_including_utilities_2_b = sa.Column(sam.types.CompressedJSONType)
-    monthly_rent_including_utilities_3plus_b = sa.Column(sam.types.CompressedJSONType)
+    monthly_rent_including_utilities_studio_apt = sa.Column(sam.types.api.CompressedJSONType)
+    monthly_rent_including_utilities_1_b = sa.Column(sam.types.api.CompressedJSONType)
+    monthly_rent_including_utilities_2_b = sa.Column(sam.types.api.CompressedJSONType)
+    monthly_rent_including_utilities_3plus_b = sa.Column(sam.types.api.CompressedJSONType)
 
     # Employment, Income, Earnings, and Work
-    employment_status = sa.Column(sam.types.CompressedJSONType)
-    average_household_income_over_time = sa.Column(sam.types.CompressedJSONType)
-    household_income = sa.Column(sam.types.CompressedJSONType)
-    annual_individual_earnings = sa.Column(sam.types.CompressedJSONType)
+    employment_status = sa.Column(sam.types.api.CompressedJSONType)
+    average_household_income_over_time = sa.Column(sam.types.api.CompressedJSONType)
+    household_income = sa.Column(sam.types.api.CompressedJSONType)
+    annual_individual_earnings = sa.Column(sam.types.api.CompressedJSONType)
 
     sources_of_household_income____percent_of_households_receiving_income = sa.Column(
-        sam.types.CompressedJSONType)
+        sam.types.api.CompressedJSONType)
     sources_of_household_income____average_income_per_household_by_income_source = sa.Column(
-        sam.types.CompressedJSONType)
+        sam.types.api.CompressedJSONType)
 
     household_investment_income____percent_of_households_receiving_investment_income = sa.Column(
-        sam.types.CompressedJSONType)
+        sam.types.api.CompressedJSONType)
     household_investment_income____average_income_per_household_by_income_source = sa.Column(
-        sam.types.CompressedJSONType)
+        sam.types.api.CompressedJSONType)
 
     household_retirement_income____percent_of_households_receiving_retirement_incom = sa.Column(
-        sam.types.CompressedJSONType)
+        sam.types.api.CompressedJSONType)
     household_retirement_income____average_income_per_household_by_income_source = sa.Column(
-        sam.types.CompressedJSONType)
+        sam.types.api.CompressedJSONType)
 
-    source_of_earnings = sa.Column(sam.types.CompressedJSONType)
+    source_of_earnings = sa.Column(sam.types.api.CompressedJSONType)
     means_of_transportation_to_work_for_workers_16_and_over = sa.Column(
-        sam.types.CompressedJSONType)
-    travel_time_to_work_in_minutes = sa.Column(sam.types.CompressedJSONType)
+        sam.types.api.CompressedJSONType)
+    travel_time_to_work_in_minutes = sa.Column(sam.types.api.CompressedJSONType)
 
     # Schools and Education
     educational_attainment_for_population_25_and_over = sa.Column(
-        sam.types.CompressedJSONType)
-    school_enrollment_age_3_to_17 = sa.Column(sam.types.CompressedJSONType)
+        sam.types.api.CompressedJSONType)
+    school_enrollment_age_3_to_17 = sa.Column(sam.types.api.CompressedJSONType)
 
 
 class SimpleZipcode(AbstractSimpleZipcode):

--- a/uszipcode/search.py
+++ b/uszipcode/search.py
@@ -15,6 +15,8 @@ import sqlalchemy as sa
 from sqlalchemy.engine import Engine
 import sqlalchemy.orm as orm
 import sqlalchemy_mate as sam
+import sqlalchemy_mate.api 
+
 from pathlib_mate import Path
 from fuzzywuzzy.process import extract, extractOne
 
@@ -151,7 +153,7 @@ class SearchEngine(object):
             self.db_file_path = db_file_path
             self.download_url = download_url
             self._download_db_file_if_not_exists()
-            self.engine = sam.EngineCreator().create_sqlite(path=self.db_file_path)
+            self.engine = sam.api.EngineCreator().create_sqlite(path=self.db_file_path)
         self.eng = self.engine
         self.session = orm.Session(self.engine)
         self.ses = self.session


### PR DESCRIPTION
This updates the code to work with the breaking changes in sqlalchemy_mate 2.0.0.1. Large portions of the code was moved behind the .api. namespace. Unfortunately, the api namespace was not automatically imported so an extra import statement was needed.

See [sqlalchemey_mate release_notes](https://github.com/MacHu-GWU/sqlalchemy_mate-project/blob/master/release-history.rst#2001-2024-05-17) for 2.0.0.1 for more details.

Additionally update the requirements to reflect the breaking change presented by this update.

All tests passing locally. 

Fixes: #79 